### PR TITLE
refactor(frontend): unify API route prefix resolution in central client

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -5,7 +5,9 @@ import { API_BASE_URL } from '@/lib/api/client';
 export default async function Dashboard() {
   let activePlugins: string[] = [];
   try {
-    const res = await fetch(`${API_BASE_URL}/system/modules`, { cache: 'no-store' });
+    const res = await fetch(`${API_BASE_URL}/system/modules`, {
+      cache: 'no-store'
+    });
     if (res.ok) {
       const data = await res.json();
       activePlugins = data.modules || [];

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -1,12 +1,11 @@
 import Link from 'next/link';
 import { ExtensionPoint } from '@/components/ExtensionPoint';
+import { API_BASE_URL } from '@/lib/api/client';
 
 export default async function Dashboard() {
   let activePlugins: string[] = [];
   try {
-    const apiUrl =
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api/v1';
-    const res = await fetch(`${apiUrl}/system/modules`, { cache: 'no-store' });
+    const res = await fetch(`${API_BASE_URL}/system/modules`, { cache: 'no-store' });
     if (res.ok) {
       const data = await res.json();
       activePlugins = data.modules || [];

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { RequireAuth } from '@/app/components/auth/AuthGuard';
 import { AppSidebar } from '@/components/AppSidebar';
 import { Header } from '@/components/Header';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { API_BASE_URL } from '@/lib/api/client';
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -19,10 +20,8 @@ export default async function DashboardLayout({
   // Next.js caches this fetch automatically, saving API hits on every page load.
   let activePlugins: string[] = [];
   try {
-    const apiUrl =
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api/v1';
     // Using no-store so plugin toggles reflect immediately without waiting 5 minutes.
-    const res = await fetch(`${apiUrl}/system/modules`, {
+    const res = await fetch(`${API_BASE_URL}/system/modules`, {
       cache: 'no-store'
     });
     if (res.ok) {

--- a/frontend/app/(dashboard)/profile/page.tsx
+++ b/frontend/app/(dashboard)/profile/page.tsx
@@ -1,15 +1,14 @@
 import { ExtensionPoint } from '@/components/ExtensionPoint';
 import { UserCircle, Mail, ShieldCheck } from 'lucide-react';
 import { cookies } from 'next/headers';
+import { API_BASE_URL } from '@/lib/api/client';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ProfilePage() {
   let activePlugins: string[] = [];
   try {
-    const apiUrl =
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api/v1';
-    const res = await fetch(`${apiUrl}/system/modules`, { cache: 'no-store' });
+    const res = await fetch(`${API_BASE_URL}/system/modules`, { cache: 'no-store' });
     if (res.ok) {
       const data = await res.json();
       activePlugins = data.modules || [];

--- a/frontend/app/(dashboard)/profile/page.tsx
+++ b/frontend/app/(dashboard)/profile/page.tsx
@@ -8,7 +8,9 @@ export const dynamic = 'force-dynamic';
 export default async function ProfilePage() {
   let activePlugins: string[] = [];
   try {
-    const res = await fetch(`${API_BASE_URL}/system/modules`, { cache: 'no-store' });
+    const res = await fetch(`${API_BASE_URL}/system/modules`, {
+      cache: 'no-store'
+    });
     if (res.ok) {
       const data = await res.json();
       activePlugins = data.modules || [];

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -2,7 +2,9 @@ import { ApiError } from './errors';
 import { readAccessToken } from '../auth-session';
 
 const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-export const API_BASE_URL = baseUrl.endsWith('/api/v1') ? baseUrl : `${baseUrl}/api/v1`;
+export const API_BASE_URL = baseUrl.endsWith('/api/v1')
+  ? baseUrl
+  : `${baseUrl}/api/v1`;
 
 interface RequestOptions extends RequestInit {
   accessToken?: string | null;

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,7 +1,8 @@
 import { ApiError } from './errors';
 import { readAccessToken } from '../auth-session';
 
-const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const rawBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const baseUrl = rawBaseUrl.replace(/\/+$/, '');
 export const API_BASE_URL = baseUrl.endsWith('/api/v1')
   ? baseUrl
   : `${baseUrl}/api/v1`;
@@ -21,8 +22,9 @@ async function request<T>(
 
   // Normalize path: strip leading /api/v1 if present to avoid duplication
   let cleanPath = path.startsWith('/') ? path : `/${path}`;
-  if (cleanPath.startsWith('/api/v1/')) {
-    cleanPath = cleanPath.substring(7);
+  cleanPath = cleanPath.replace(/^(?:\/api\/v1)+/, '');
+  if (cleanPath && !cleanPath.startsWith('/') && !cleanPath.startsWith('?')) {
+    cleanPath = `/${cleanPath}`;
   }
 
   // Resolve token: explicit token > auth-session token > null

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,7 +1,8 @@
 import { ApiError } from './errors';
 import { readAccessToken } from '../auth-session';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+export const API_BASE_URL = baseUrl.endsWith('/api/v1') ? baseUrl : `${baseUrl}/api/v1`;
 
 interface RequestOptions extends RequestInit {
   accessToken?: string | null;
@@ -16,6 +17,12 @@ async function request<T>(
 ): Promise<T> {
   const { accessToken, ...init } = options;
 
+  // Normalize path: strip leading /api/v1 if present to avoid duplication
+  let cleanPath = path.startsWith('/') ? path : `/${path}`;
+  if (cleanPath.startsWith('/api/v1/')) {
+    cleanPath = cleanPath.substring(7);
+  }
+
   // Resolve token: explicit token > auth-session token > null
   const token = accessToken !== undefined ? accessToken : readAccessToken();
 
@@ -29,7 +36,7 @@ async function request<T>(
     headers.set('Content-Type', 'application/json');
   }
 
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const response = await fetch(`${API_BASE_URL}${cleanPath}`, {
     ...init,
     headers
   });

--- a/frontend/lib/auth-api.ts
+++ b/frontend/lib/auth-api.ts
@@ -22,9 +22,9 @@ export function signup(payload: {
   email: string;
   password: string;
 }) {
-  return apiClient.post<AuthResponseData>('/api/v1/auth/signup', payload);
+  return apiClient.post<AuthResponseData>('/auth/signup', payload);
 }
 
 export function login(payload: { email: string; password: string }) {
-  return apiClient.post<AuthResponseData>('/api/v1/auth/login', payload);
+  return apiClient.post<AuthResponseData>('/auth/login', payload);
 }

--- a/frontend/lib/budget-api.ts
+++ b/frontend/lib/budget-api.ts
@@ -2,57 +2,57 @@ import { apiClient } from './api/client';
 
 export const budgetAPI = {
   createBudget(eventId: string, budgetData: Record<string, unknown>) {
-    return apiClient.post(`/api/v1/events/${eventId}/budget`, budgetData);
+    return apiClient.post(`/events/${eventId}/budget`, budgetData);
   },
 
   getEventBudget(eventId: string) {
-    return apiClient.get(`/api/v1/events/${eventId}/budget`);
+    return apiClient.get(`/events/${eventId}/budget`);
   },
 
   getBudgetById(budgetId: string) {
-    return apiClient.get(`/api/v1/budget/${budgetId}`);
+    return apiClient.get(`/budget/${budgetId}`);
   },
 
   updateBudget(budgetId: string, updateData: Record<string, unknown>) {
-    return apiClient.put(`/api/v1/budget/${budgetId}`, updateData);
+    return apiClient.put(`/budget/${budgetId}`, updateData);
   },
 
   approveBudget(budgetId: string, userId: string) {
-    return apiClient.post(`/api/v1/budget/${budgetId}/approve`, { userId });
+    return apiClient.post(`/budget/${budgetId}/approve`, { userId });
   },
 
   rejectBudget(budgetId: string) {
-    return apiClient.post(`/api/v1/budget/${budgetId}/reject`, {});
+    return apiClient.post(`/budget/${budgetId}/reject`, {});
   },
 
   logExpense(budgetId: string, expenseData: Record<string, unknown>) {
-    return apiClient.post(`/api/v1/budget/${budgetId}/expense`, expenseData);
+    return apiClient.post(`/budget/${budgetId}/expense`, expenseData);
   },
 
   getBudgetExpenses(budgetId: string) {
-    return apiClient.get(`/api/v1/budget/${budgetId}/expenses`);
+    return apiClient.get(`/budget/${budgetId}/expenses`);
   },
 
   getExpenseById(expenseId: string) {
-    return apiClient.get(`/api/v1/budget/expense/${expenseId}`);
+    return apiClient.get(`/budget/expense/${expenseId}`);
   },
 
   updateExpense(expenseId: string, updateData: Record<string, unknown>) {
-    return apiClient.put(`/api/v1/budget/expense/${expenseId}`, updateData);
+    return apiClient.put(`/budget/expense/${expenseId}`, updateData);
   },
 
   markExpenseAsPaid(expenseId: string, paymentMethod: string) {
-    return apiClient.post(`/api/v1/budget/expense/${expenseId}/mark-paid`, {
+    return apiClient.post(`/budget/expense/${expenseId}/mark-paid`, {
       paymentMethod
     });
   },
 
   getBudgetSummary(budgetId: string) {
-    return apiClient.get(`/api/v1/budget/${budgetId}/summary`);
+    return apiClient.get(`/budget/${budgetId}/summary`);
   },
 
   getBudgetVsActual(budgetId: string) {
-    return apiClient.get(`/api/v1/budget/${budgetId}/vs-actual`);
+    return apiClient.get(`/budget/${budgetId}/vs-actual`);
   }
 };
 

--- a/frontend/lib/calendar-api.ts
+++ b/frontend/lib/calendar-api.ts
@@ -18,7 +18,7 @@ export interface CalendarEvent {
 }
 
 export function fetchAllCalendarEvents(accessToken?: string) {
-  return apiClient.get<CalendarEvent[]>('/api/v1/calendar', { accessToken });
+  return apiClient.get<CalendarEvent[]>('/calendar', { accessToken });
 }
 
 export function fetchCalendarEventsByRange(
@@ -31,7 +31,7 @@ export function fetchCalendarEventsByRange(
     endDate
   });
   return apiClient.get<CalendarEvent[]>(
-    `/api/v1/calendar/range?${params.toString()}`,
+    `/calendar/range?${params.toString()}`,
     { accessToken }
   );
 }
@@ -48,7 +48,7 @@ export function createCalendarEvent(
     linkedEventId?: string;
   }
 ) {
-  return apiClient.post<CalendarEvent>('/api/v1/calendar', payload, {
+  return apiClient.post<CalendarEvent>('/calendar', payload, {
     accessToken
   });
 }
@@ -57,7 +57,7 @@ export function deleteCalendarEvent(
   accessToken: string | undefined,
   eventId: string
 ) {
-  return apiClient.delete(`/api/v1/calendar/${eventId}`, undefined, {
+  return apiClient.delete(`/calendar/${eventId}`, undefined, {
     accessToken
   });
 }

--- a/frontend/lib/checkin-api.ts
+++ b/frontend/lib/checkin-api.ts
@@ -66,8 +66,7 @@ export async function fetchAttendanceStats(
   accessToken: string | undefined,
   eventId: string
 ): Promise<AttendanceStats> {
-  return apiClient.get<AttendanceStats>(
-    `/events/${eventId}/attendance-stats`,
-    { accessToken }
-  );
+  return apiClient.get<AttendanceStats>(`/events/${eventId}/attendance-stats`, {
+    accessToken
+  });
 }

--- a/frontend/lib/checkin-api.ts
+++ b/frontend/lib/checkin-api.ts
@@ -25,7 +25,7 @@ export async function fetchCheckIns(
   eventId: string
 ): Promise<CheckInRecord[]> {
   const data = await apiClient.get<{ checkIns?: CheckInRecord[] }>(
-    `/api/v1/events/${eventId}/checkins`,
+    `/events/${eventId}/checkins`,
     { accessToken }
   );
   return data?.checkIns || (data as unknown as CheckInRecord[]) || [];
@@ -37,7 +37,7 @@ export async function createCheckIn(
   userId: string
 ): Promise<CheckInRecord> {
   return apiClient.post<CheckInRecord>(
-    `/api/v1/events/${eventId}/checkins`,
+    `/events/${eventId}/checkins`,
     { userId },
     { accessToken }
   );
@@ -49,14 +49,14 @@ export async function getCheckInStatus(
   userId: string
 ): Promise<CheckInRecord> {
   return apiClient.get<CheckInRecord>(
-    `/api/v1/events/${eventId}/checkins/status/${userId}`,
+    `/events/${eventId}/checkins/status/${userId}`,
     { accessToken }
   );
 }
 
 export async function scanQRCode(qrCode: string): Promise<CheckInRecord> {
   const data = await apiClient.post<{ checkIn: CheckInRecord }>(
-    `/api/v1/checkins/scan`,
+    `/checkins/scan`,
     { qrCode }
   );
   return data?.checkIn || (data as unknown as CheckInRecord);
@@ -67,7 +67,7 @@ export async function fetchAttendanceStats(
   eventId: string
 ): Promise<AttendanceStats> {
   return apiClient.get<AttendanceStats>(
-    `/api/v1/events/${eventId}/attendance-stats`,
+    `/events/${eventId}/attendance-stats`,
     { accessToken }
   );
 }

--- a/frontend/lib/event-api.ts
+++ b/frontend/lib/event-api.ts
@@ -24,16 +24,16 @@ export interface EventItem {
 }
 
 export function fetchEvents() {
-  return apiClient.get<EventItem[]>('/api/v1/events');
+  return apiClient.get<EventItem[]>('/events');
 }
 
 export function fetchEventById(eventId: string) {
-  return apiClient.get<EventItem>(`/api/v1/events/${eventId}`);
+  return apiClient.get<EventItem>(`/events/${eventId}`);
 }
 
 export function registerForEvent(
   eventId: string,
   payload: { attendeeName: string; attendeeEmail: string }
 ) {
-  return apiClient.post(`/api/v1/events/${eventId}/registrations`, payload);
+  return apiClient.post(`/events/${eventId}/registrations`, payload);
 }

--- a/frontend/lib/resource-api.ts
+++ b/frontend/lib/resource-api.ts
@@ -57,10 +57,9 @@ export const resourceAPI = {
   },
 
   updateAllocationStatus(allocationId: string, status: string) {
-    return apiClient.put(
-      `/resources/allocations/${allocationId}/status`,
-      { status }
-    );
+    return apiClient.put(`/resources/allocations/${allocationId}/status`, {
+      status
+    });
   },
 
   updateMaintenance(resourceId: string, maintenanceDate: string) {

--- a/frontend/lib/resource-api.ts
+++ b/frontend/lib/resource-api.ts
@@ -2,7 +2,7 @@ import { apiClient } from './api/client';
 
 export const resourceAPI = {
   createResource(resourceData: Record<string, unknown>) {
-    return apiClient.post('/api/v1/resources', resourceData);
+    return apiClient.post('/resources', resourceData);
   },
 
   getAllResources(filters: Record<string, unknown> = {}) {
@@ -12,7 +12,7 @@ export const resourceAPI = {
     if (filters.condition)
       params.append('condition', String(filters.condition));
 
-    return apiClient.get(`/api/v1/resources?${params}`);
+    return apiClient.get(`/resources?${params}`);
   },
 
   getAvailableResources(filters: Record<string, unknown> = {}) {
@@ -22,19 +22,19 @@ export const resourceAPI = {
     if (filters.condition)
       params.append('condition', String(filters.condition));
 
-    return apiClient.get(`/api/v1/resources/available?${params}`);
+    return apiClient.get(`/resources/available?${params}`);
   },
 
   getResourceById(resourceId: string) {
-    return apiClient.get(`/api/v1/resources/${resourceId}`);
+    return apiClient.get(`/resources/${resourceId}`);
   },
 
   updateResource(resourceId: string, updateData: Record<string, unknown>) {
-    return apiClient.put(`/api/v1/resources/${resourceId}`, updateData);
+    return apiClient.put(`/resources/${resourceId}`, updateData);
   },
 
   deleteResource(resourceId: string) {
-    return apiClient.delete(`/api/v1/resources/${resourceId}`);
+    return apiClient.delete(`/resources/${resourceId}`);
   },
 
   allocateResourceToEvent(
@@ -43,28 +43,28 @@ export const resourceAPI = {
     allocationData: Record<string, unknown>
   ) {
     return apiClient.post(
-      `/api/v1/events/${eventId}/resources/${resourceId}`,
+      `/events/${eventId}/resources/${resourceId}`,
       allocationData
     );
   },
 
   getEventResources(eventId: string) {
-    return apiClient.get(`/api/v1/events/${eventId}/resources`);
+    return apiClient.get(`/events/${eventId}/resources`);
   },
 
   getResourceAllocations(resourceId: string) {
-    return apiClient.get(`/api/v1/resources/${resourceId}/allocations`);
+    return apiClient.get(`/resources/${resourceId}/allocations`);
   },
 
   updateAllocationStatus(allocationId: string, status: string) {
     return apiClient.put(
-      `/api/v1/resources/allocations/${allocationId}/status`,
+      `/resources/allocations/${allocationId}/status`,
       { status }
     );
   },
 
   updateMaintenance(resourceId: string, maintenanceDate: string) {
-    return apiClient.put(`/api/v1/resources/${resourceId}/maintenance`, {
+    return apiClient.put(`/resources/${resourceId}/maintenance`, {
       maintenanceDate
     });
   }

--- a/frontend/lib/scheduling-api.ts
+++ b/frontend/lib/scheduling-api.ts
@@ -2,23 +2,23 @@ import { apiClient } from './api/client';
 
 export const schedulingAPI = {
   createTimeSlot(eventId: string, slotData: Record<string, unknown>) {
-    return apiClient.post(`/api/v1/events/${eventId}/schedule`, slotData);
+    return apiClient.post(`/events/${eventId}/schedule`, slotData);
   },
 
   getEventSchedule(eventId: string) {
-    return apiClient.get(`/api/v1/events/${eventId}/schedule`);
+    return apiClient.get(`/events/${eventId}/schedule`);
   },
 
   getTimeSlot(slotId: string) {
-    return apiClient.get(`/api/v1/schedule/${slotId}`);
+    return apiClient.get(`/schedule/${slotId}`);
   },
 
   updateTimeSlot(slotId: string, updateData: Record<string, unknown>) {
-    return apiClient.put(`/api/v1/schedule/${slotId}`, updateData);
+    return apiClient.put(`/schedule/${slotId}`, updateData);
   },
 
   deleteTimeSlot(slotId: string) {
-    return apiClient.delete(`/api/v1/schedule/${slotId}`);
+    return apiClient.delete(`/schedule/${slotId}`);
   },
 
   getAllConflicts(filters: Record<string, unknown> = {}) {
@@ -27,15 +27,15 @@ export const schedulingAPI = {
       params.append('resolved', String(filters.resolved));
     if (filters.severity) params.append('severity', String(filters.severity));
 
-    return apiClient.get(`/api/v1/schedule/conflicts?${params}`);
+    return apiClient.get(`/schedule/conflicts?${params}`);
   },
 
   getSlotConflicts(slotId: string) {
-    return apiClient.get(`/api/v1/schedule/${slotId}/conflicts`);
+    return apiClient.get(`/schedule/${slotId}/conflicts`);
   },
 
   resolveConflict(conflictId: string, resolution: string) {
-    return apiClient.put(`/api/v1/schedule/conflicts/${conflictId}/resolve`, {
+    return apiClient.put(`/schedule/conflicts/${conflictId}/resolve`, {
       resolution
     });
   },
@@ -50,11 +50,11 @@ export const schedulingAPI = {
       endTime: new Date(endTime).toISOString()
     });
 
-    return apiClient.get(`/api/v1/schedule/venue/${venue}/available?${params}`);
+    return apiClient.get(`/schedule/venue/${venue}/available?${params}`);
   },
 
   getScheduleOverview(eventId: string) {
-    return apiClient.get(`/api/v1/events/${eventId}/schedule/overview`);
+    return apiClient.get(`/events/${eventId}/schedule/overview`);
   }
 };
 

--- a/frontend/lib/task-api.ts
+++ b/frontend/lib/task-api.ts
@@ -20,7 +20,7 @@ export interface TaskItem {
 }
 
 export function fetchTasks(accessToken?: string) {
-  return apiClient.get<TaskItem[]>('/api/v1/tasks', { accessToken });
+  return apiClient.get<TaskItem[]>('/tasks', { accessToken });
 }
 
 export function createTask(
@@ -33,7 +33,7 @@ export function createTask(
     priority: TaskPriority;
   }
 ) {
-  return apiClient.post<TaskItem>('/api/v1/tasks', payload, { accessToken });
+  return apiClient.post<TaskItem>('/tasks', payload, { accessToken });
 }
 
 export function assignTask(
@@ -42,7 +42,7 @@ export function assignTask(
   assigneeName: string
 ) {
   return apiClient.patch<TaskItem>(
-    `/api/v1/tasks/${taskId}/assign`,
+    `/tasks/${taskId}/assign`,
     { assigneeName },
     { accessToken }
   );
@@ -54,7 +54,7 @@ export function updateTaskStatus(
   status: TaskStatus
 ) {
   return apiClient.patch<TaskItem>(
-    `/api/v1/tasks/${taskId}/status`,
+    `/tasks/${taskId}/status`,
     { status },
     { accessToken }
   );
@@ -66,7 +66,7 @@ export function updateTaskPriority(
   priority: TaskPriority
 ) {
   return apiClient.patch<TaskItem>(
-    `/api/v1/tasks/${taskId}/priority`,
+    `/tasks/${taskId}/priority`,
     { priority },
     { accessToken }
   );
@@ -78,7 +78,7 @@ export function addTaskDependency(
   dependencyId: string
 ) {
   return apiClient.post<TaskItem>(
-    `/api/v1/tasks/${taskId}/dependencies`,
+    `/tasks/${taskId}/dependencies`,
     { dependencyId },
     { accessToken }
   );
@@ -90,7 +90,7 @@ export function removeTaskDependency(
   dependencyId: string
 ) {
   return apiClient.delete<TaskItem>(
-    `/api/v1/tasks/${taskId}/dependencies`,
+    `/tasks/${taskId}/dependencies`,
     { dependencyId },
     { accessToken }
   );

--- a/frontend/lib/vendor-api.ts
+++ b/frontend/lib/vendor-api.ts
@@ -2,7 +2,7 @@ import { apiClient } from './api/client';
 
 export const vendorAPI = {
   createVendor(vendorData: Record<string, unknown>) {
-    return apiClient.post('/api/v1/vendors', vendorData);
+    return apiClient.post('/vendors', vendorData);
   },
 
   getAllVendors(filters: Record<string, unknown> = {}) {
@@ -10,19 +10,19 @@ export const vendorAPI = {
     if (filters.category) params.append('category', String(filters.category));
     if (filters.status) params.append('status', String(filters.status));
 
-    return apiClient.get(`/api/v1/vendors?${params}`);
+    return apiClient.get(`/vendors?${params}`);
   },
 
   getVendorById(vendorId: string) {
-    return apiClient.get(`/api/v1/vendors/${vendorId}`);
+    return apiClient.get(`/vendors/${vendorId}`);
   },
 
   updateVendor(vendorId: string, updateData: Record<string, unknown>) {
-    return apiClient.put(`/api/v1/vendors/${vendorId}`, updateData);
+    return apiClient.put(`/vendors/${vendorId}`, updateData);
   },
 
   deleteVendor(vendorId: string) {
-    return apiClient.delete(`/api/v1/vendors/${vendorId}`);
+    return apiClient.delete(`/vendors/${vendorId}`);
   },
 
   assignVendorToEvent(
@@ -31,27 +31,27 @@ export const vendorAPI = {
     assignmentData: Record<string, unknown>
   ) {
     return apiClient.post(
-      `/api/v1/events/${eventId}/vendors/${vendorId}`,
+      `/events/${eventId}/vendors/${vendorId}`,
       assignmentData
     );
   },
 
   getEventVendors(eventId: string) {
-    return apiClient.get(`/api/v1/events/${eventId}/vendors`);
+    return apiClient.get(`/events/${eventId}/vendors`);
   },
 
   getVendorAssignments(vendorId: string) {
-    return apiClient.get(`/api/v1/vendors/${vendorId}/assignments`);
+    return apiClient.get(`/vendors/${vendorId}/assignments`);
   },
 
   updateAssignmentStatus(assignmentId: string, status: string) {
-    return apiClient.put(`/api/v1/vendors/assignments/${assignmentId}/status`, {
+    return apiClient.put(`/vendors/assignments/${assignmentId}/status`, {
       status
     });
   },
 
   rateVendor(vendorId: string, rating: number) {
-    return apiClient.post(`/api/v1/vendors/${vendorId}/rate`, { rating });
+    return apiClient.post(`/vendors/${vendorId}/rate`, { rating });
   }
 };
 


### PR DESCRIPTION
## 📝 Description

This PR refactors how API namespaces are resolved in the frontend. It centralizes the `/api/v1` prefix logic into the main API client, removing repetitive hardcoded prefixes across individual service files, while maintaining backward-compatibility.

Key improvements:
* **Auto-prefixing Base URL**: Centralized `API_BASE_URL` in `client.ts` automatically resolves to include `/api/v1` (with production environments fallbacks).
* **Safe Path Sanitization**: Configured the request router to automatically strip any duplicate `/api/v1` prefixes from paths. This ensures that third-party plugins or legacy files referencing `/api/v1/` directly will continue to function without issues.
* **Service Cleanups**: Removed hardcoded `/api/v1` prefixes from all 10 frontend API service files.
* **Server-Side Fetch Simplifications**: Streamlined the layout, dashboard page, and profile page to fetch `/system/modules` relative to the exported `API_BASE_URL`.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (fixes an existing issue)
- [ ] ✨ New feature (adds new functionality)
- [x] 🔄 Enhancement (improves existing functionality)
- [ ] 📖 Documentation update
- [ ] 🔧 Chore (dependency update, config change)
- [ ] 🎨 Style/formatting
- [x] ♻️ Refactor (code restructuring without behavior change)

## 🔗 Related Issues

Closes #

## 📐 Modules Affected

- [ ] `apps/backend`
- [x] `apps/frontend`
- [ ] Backend module (specify: auth, club, institute, event, checkin, task, calendar, vendor, resource, scheduling, budget):
- [ ] Database schemas
- [ ] CI/CD workflows
- [ ] Configuration / Environment variables

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing (describe below)

*Verified that the frontend codebase formats (`pnpm format`), lints cleanly (`pnpm lint`), compiles TypeScript without warnings (`tsc --noEmit`), and builds successfully in production mode (`next build`).*

## 📋 Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/NITRR-Official/CampusOS/blob/dev/docs/contributing/CONTRIBUTING.md) and [CODING_GUIDELINES.md](https://github.com/NITRR-Official/CampusOS/blob/dev/docs/contributing/CODING_GUIDELINES.md)
- [x] PR targets `dev` branch
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My code follows the project's code style
- [x] I have updated documentation if needed
- [ ] I have added tests for new functionality
- [x] `pnpm format` / `pnpm lint` / `pnpm type-check` / `pnpm build` all pass

## 🖼️ Screenshots

*None.*

## 📚 Additional Context

This resolves the blank dashboard/navigation issue observed on Vercel deployments where `NEXT_PUBLIC_API_URL` lacked the `/api/v1` suffix.