### PR TITLE
feat(core): implement dynamic permission registry for RBAC

### DIFF
--- a/apps/club/src/index.js
+++ b/apps/club/src/index.js
@@ -19,6 +19,29 @@ export async function init(app, registry, eventBus) {
       '/api/v1/clubs/:clubId/members/:memberUserId/role'
     ]
   });
+
+  // Register atomic permissions for RBAC
+  if (registry.permissions) {
+    registry.permissions.register({
+      id: 'club:manage',
+      module: 'club',
+      label: 'Manage Club Settings',
+      description:
+        'Allows editing core club details like description and category'
+    });
+    registry.permissions.register({
+      id: 'member:manage',
+      module: 'club',
+      label: 'Manage Members',
+      description: 'Allows kicking members and assigning basic roles'
+    });
+    registry.permissions.register({
+      id: 'role:manage',
+      module: 'club',
+      label: 'Manage Roles',
+      description: 'Allows creating custom roles and editing the role hierarchy'
+    });
+  }
 }
 
 export default init;

--- a/apps/event/src/index.js
+++ b/apps/event/src/index.js
@@ -20,6 +20,22 @@ export async function init(app, registry, eventBus) {
       '/api/v1/events/:eventId/registrations'
     ]
   });
+
+  // Register atomic permissions for RBAC
+  if (registry.permissions) {
+    registry.permissions.register({
+      id: 'event:create',
+      module: 'event',
+      label: 'Create Events',
+      description: 'Allows creating new events for a club'
+    });
+    registry.permissions.register({
+      id: 'event:manage',
+      module: 'event',
+      label: 'Manage Events',
+      description: 'Allows editing, publishing, and deleting events'
+    });
+  }
 }
 
 export default init;

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -83,6 +83,12 @@ export async function createApp(registry) {
     res.json({ success: true, modules: activeModules });
   });
 
+  // Public endpoint for frontend to discover all registered permissions
+  app.get('/api/v1/system/permissions', (req, res) => {
+    const permissions = registry.permissions.getAllGrouped();
+    res.json({ success: true, permissions });
+  });
+
   // 5. Authentication - Verify JWT before protected routes
   registerJwtAuthenticator(registry);
   registry.registerService('requireRoles', requireRoles);

--- a/backend/src/core/permission-registry.js
+++ b/backend/src/core/permission-registry.js
@@ -1,0 +1,71 @@
+/**
+ * Dynamic Permission Registry
+ * Allows plugins to register their available atomic permissions at runtime.
+ * This ensures the core system knows about all permissions without static coupling.
+ */
+
+export class PermissionRegistry {
+  constructor() {
+    // Map<permissionId, { id, module, description, label }>
+    this.permissions = new Map();
+  }
+
+  /**
+   * Register a new permission
+   * @param {Object} permission
+   * @param {string} permission.id - The atomic permission string (e.g., 'event:create')
+   * @param {string} permission.module - The module it belongs to (e.g., 'event')
+   * @param {string} permission.description - Description for the UI
+   * @param {string} [permission.label] - Optional friendly name for the UI
+   */
+  register(permission) {
+    if (!permission.id || !permission.module) {
+      throw new Error('Permission must have an id and a module');
+    }
+
+    if (this.permissions.has(permission.id)) {
+      console.warn(
+        `[PermissionRegistry] Overwriting existing permission: ${permission.id}`
+      );
+    }
+
+    this.permissions.set(permission.id, {
+      id: permission.id,
+      module: permission.module,
+      description: permission.description || '',
+      label: permission.label || permission.id
+    });
+  }
+
+  /**
+   * Get all permissions grouped by module
+   * @returns {Object} Grouped permissions { "event": [ ... ], "club": [ ... ] }
+   */
+  getAllGrouped() {
+    const grouped = {};
+    for (const perm of this.permissions.values()) {
+      if (!grouped[perm.module]) {
+        grouped[perm.module] = [];
+      }
+      grouped[perm.module].push(perm);
+    }
+    return grouped;
+  }
+
+  /**
+   * Get all permissions as a flat list
+   * @returns {Array} Array of all permissions
+   */
+  getAll() {
+    return Array.from(this.permissions.values());
+  }
+
+  /**
+   * Check if a specific permission exists in the registry
+   * @param {string} id
+   * @returns {boolean}
+   */
+  has(id) {
+    return this.permissions.has(id);
+  }
+}

--- a/backend/src/utils/registry.js
+++ b/backend/src/utils/registry.js
@@ -3,12 +3,15 @@
  * Central registry for managing plugin modules and services
  */
 
+import { PermissionRegistry } from '../core/permission-registry.js';
+
 class ModuleRegistry {
   constructor() {
     this.modules = new Map();
     this.services = new Map();
     this.authenticators = new Map();
     this.resolvers = new Map();
+    this.permissions = new PermissionRegistry();
   }
 
   /**


### PR DESCRIPTION
## 📝 Description

This PR implements the foundational **Dynamic Permission Registry** required for the upcoming Discord-style Resource-Based Access Control (RBAC) system. 

Instead of hardcoding global permissions (which violates our loosely coupled micro-plugin architecture), this PR allows the core system to act as a centralized permission registry. Plugins dynamically declare their available atomic permissions during their initialization phase.

**Key Additions:**
- Added `PermissionRegistry` class to the core backend.
- Integrated the registry natively into `ModuleRegistry` so all plugins receive it on boot.
- Added a new public route `GET /api/v1/system/permissions` that aggregates and returns all dynamically registered permissions (grouped by module) so the frontend Role Settings UI can render them dynamically.
- Proof-of-concept integration: The `event` and `club` plugins now register their permissions (`event:create`, `club:manage`, etc.) on boot.

## 🎯 Type of Change

- [ ] 🐛 Bug fix (fixes an existing issue)
- [x] ✨ New feature (adds new functionality)
- [ ] 🔄 Enhancement (improves existing functionality)
- [ ] 📖 Documentation update
- [ ] 🔧 Chore (dependency update, config change)
- [ ] 🎨 Style/formatting
- [ ] ♻️ Refactor (code restructuring without behavior change)

## 🔗 Related Issues

*N/A* (Blocks upcoming RBAC implementation)

## 📐 Modules Affected

- [x] `apps/backend` (Core framework)
- [ ] `apps/frontend`
- [x] Backend module: `club`, `event`
- [ ] Database schemas
- [ ] CI/CD workflows
- [ ] Configuration / Environment variables

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing 
  - Verified that `GET /api/v1/system/permissions` returns a structured JSON payload of all permissions registered by the active plugins.

## 📋 Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/NITRR-Official/CampusOS/blob/dev/docs/contributing/CONTRIBUTING.md) and [CODING_GUIDELINES.md](https://github.com/NITRR-Official/CampusOS/blob/dev/docs/contributing/CODING_GUIDELINES.md)
- [x] PR targets `dev` branch
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My code follows the project's code style
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality
- [x] `pnpm format` / `pnpm lint` / `pnpm type-check` / `pnpm build` / `pnpm test` all pass

## 🖼️ Screenshots

*N/A - Backend core architecture changes.*

## 📚 Additional Context

This PR serves as the core foundation for the RBAC contributor. The Mongoose schemas and middleware can now safely query `registry.permissions.has('event:create')` without needing hardcoded enums.
